### PR TITLE
Tweak brim-conf.yaml

### DIFF
--- a/brim-conf.yaml
+++ b/brim-conf.yaml
@@ -48,6 +48,8 @@ outputs:
   # Extensible Event Format (nicknamed EVE) event log in JSON format
   - eve-log:
       enabled: yes
+      community_id: yes
+      community-id-seed: 0
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
       #prefix: "@cee: " # prefix to prepend to each log entry
@@ -73,20 +75,20 @@ outputs:
       #    batch-size: 10 ## number of entry to keep in buffer
 
       # Include top level metadata. Default yes.
-      #metadata: no
+      metadata: no
 
       types:
         - alert:
-            # payload: yes             # enable dumping payload in Base64
+            payload: no             # enable dumping payload in Base64
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
-            # payload-printable: yes   # enable dumping payload in printable (lossy) format
-            # packet: yes              # enable dumping of packet (without stream segments)
-            # http-body: yes           # enable dumping of http body in Base64
-            # http-body-printable: yes # enable dumping of http body in printable format
+            payload-printable: no   # enable dumping payload in printable (lossy) format
+            packet: no              # enable dumping of packet (without stream segments)
+            http-body: no           # enable dumping of http body in Base64
+            http-body-printable: no # enable dumping of http body in printable format
 
             # Enable the logging of tagged packets for rules using the
             # "tag" keyword.
-            tagged-packets: yes
+            tagged-packets: no
 
             # Configure the metadata to be logged along with an
             # alert. The following shows the default configuration
@@ -116,6 +118,8 @@ outputs:
             # or forward proxied.
             xff:
               enabled: no
+        - anomaly:
+            enabled: no
         - http:
             enabled: no
         - dns:


### PR DESCRIPTION
- Enable community id
- Disable a number of things to output, some of which are "for
  safety" (e.g. I haven't observed them yet, and as such the json type
  configuration doesn't know about them), and others because we don't
  want them (event_type other than "alert").