### PR TITLE
Point to Brim fork of Suricata

### DIFF
--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -57,8 +57,8 @@ jobs:
         mkdir -p $HOME/suricata/share/file
         cp /usr/local/Cellar/libmagic/$version/share/misc/magic.mgc $HOME/suricata/share/file
     - name: create zip
-      run: cd $HOME && zip -r suricata-v5.0.3-brim4.$(go env GOOS)-$(go env GOARCH).zip suricata
+      run: cd $HOME && zip -r suricata-v5.0.3-brim5.$(go env GOOS)-$(go env GOARCH).zip suricata
     - if: github.ref == 'refs/heads/master'
       name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil cp $HOME/suricata-v5.0.3-brim4.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/
+        gsutil cp $HOME/suricata-v5.0.3-brim5.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -22,12 +22,14 @@ jobs:
         brew install rust pkg-config
         brew install jansson libmagic libnet libyaml lz4 nspr nss pcre bzip2
         pip3 install pyyaml
-    - name: download suricata sources
+    - name: clone Suricata and autogen
       run: |
-        curl -o suricata-5.0.3.tar.gz https://www.openinfosecfoundation.org/download/suricata-5.0.3.tar.gz
-        tar xvzf suricata-5.0.3.tar.gz
+        git clone --depth 1 --branch brim-suricata-5.0.3 https://github.com/brimsec/suricata.git
+        cd suricata
+        git clone https://github.com/OISF/libhtp -b 0.5.x
+        ./autogen.sh
     - name: configure and build
-      run: cd suricata-5.0.3 && ./configure --enable-static=yes --enable-shared=no --prefix=$HOME/suricata && make -j2
+      run: ./configure --enable-static=yes --enable-shared=no --prefix=$HOME/suricata && make -j2
     - name: build static binary
       run: |
         cp Makefile.brim suricata-5.0.3/src

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -21,6 +21,7 @@ jobs:
       run: |
         brew install rust pkg-config
         brew install jansson libmagic libnet libyaml lz4 nspr nss pcre bzip2
+        brew install autoconf automake libtool
         pip3 install pyyaml
     - name: clone Suricata and autogen
       run: |
@@ -28,12 +29,18 @@ jobs:
         cd suricata
         git clone https://github.com/OISF/libhtp -b 0.5.x
         ./autogen.sh
+    - name: get suricata-update
+      run: |
+        curl -L \
+              https://github.com/OISF/suricata-update/archive/master.tar.gz | \
+              tar zxvf - --strip-components=1
+      working-directory: suricata/suricata-update
     - name: configure and build
-      run: ./configure --enable-static=yes --enable-shared=no --prefix=$HOME/suricata && make -j2
+      run: cd suricata && ./configure --enable-static=yes --enable-shared=no --prefix=$HOME/suricata && make -j2
     - name: build static binary
       run: |
-        cp Makefile.brim suricata-5.0.3/src
-        cd suricata-5.0.3/src
+        cp Makefile.brim suricata/src
+        cd suricata/src
         # remove the dynamically-linked suricata and re-link statically using our Makefile
         rm suricata
         make -f Makefile.brim

--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -44,8 +44,8 @@ jobs:
         cp brim-conf.yaml $HOME/suricata
         cp suricatarunner-linux $HOME/suricata/suricatarunner
     - name: create zip
-      run: cd $HOME && zip -r suricata-v5.0.3-brim4.$(go env GOOS)-$(go env GOARCH).zip suricata
+      run: cd $HOME && zip -r suricata-v5.0.3-brim5.$(go env GOOS)-$(go env GOARCH).zip suricata
     - if: github.ref == 'refs/heads/master'
       name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil cp $HOME/suricata-v5.0.3-brim4.linux-amd64.zip gs://brimsec/suricata/
+        gsutil cp $HOME/suricata-v5.0.3-brim5.linux-amd64.zip gs://brimsec/suricata/

--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -30,9 +30,15 @@ jobs:
         cd suricata
         git clone https://github.com/OISF/libhtp -b 0.5.x
         ./autogen.sh
+    - name: get suricata-update
+      run: |
+        curl -L \
+              https://github.com/OISF/suricata-update/archive/master.tar.gz | \
+              tar zxvf - --strip-components=1
+      working-directory: suricata/suricata-update
     - name: configure and build
       # --disable-gccmatch-native is to avoid "illegal instruction" crashes when running on a different x86_64 CPU.
-      run: ./configure --disable-gccmarch-native --enable-static=yes --enable-shared=no --prefix=$HOME/suricata && make -j2 && make install-full
+      run: cd suricata && ./configure --disable-gccmarch-native --enable-static=yes --enable-shared=no --prefix=$HOME/suricata && make -j2 && make install-full
     - name: add brim files
       run: |
         cp brim-conf.yaml $HOME/suricata

--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -24,13 +24,15 @@ jobs:
         automake libtool libpcap-dev libnet1-dev libyaml-0-2 libyaml-dev zlib1g zlib1g-dev \
         libcap-ng-dev libcap-ng0 make libmagic-dev libjansson-dev libjansson4 pkg-config libnss3-dev \
         libnspr4-dev liblz4-dev zip
-    - name: download suricata sources
+    - name: clone Suricata and autogen
       run: |
-        curl -o suricata-5.0.3.tar.gz https://www.openinfosecfoundation.org/download/suricata-5.0.3.tar.gz
-        tar xvzf suricata-5.0.3.tar.gz
+        git clone --depth 1 --branch brim-suricata-5.0.3 https://github.com/brimsec/suricata.git
+        cd suricata
+        git clone https://github.com/OISF/libhtp -b 0.5.x
+        ./autogen.sh
     - name: configure and build
       # --disable-gccmatch-native is to avoid "illegal instruction" crashes when running on a different x86_64 CPU.
-      run: cd suricata-5.0.3 && ./configure --disable-gccmarch-native --enable-static=yes --enable-shared=no --prefix=$HOME/suricata && make -j2 && make install-full
+      run: ./configure --disable-gccmarch-native --enable-static=yes --enable-shared=no --prefix=$HOME/suricata && make -j2 && make install-full
     - name: add brim files
       run: |
         cp brim-conf.yaml $HOME/suricata

--- a/suricatarunner-linux
+++ b/suricatarunner-linux
@@ -9,4 +9,4 @@ rule-files:
   - $dir/var/lib/suricata/rules/suricata.rules
 " >> $dir/brim-conf-run.yaml
 
-exec "$dir/bin/suricata" -c "$dir/brim-conf-run.yaml" --set classification-file="$dir/etc/suricata/classification.config" --set reference-config-file="$dir/etc/suricata/reference.config" --set threshold-file="$dir/etc/suricata/threshold.config" -r /dev/stdin
+exec "$dir/bin/suricata" -c "$dir/brim-conf-run.yaml" --set classification-file="$dir/etc/suricata/classification.config" --set reference-config-file="$dir/etc/suricata/reference.config" --set threshold-file="$dir/etc/suricata/threshold.config" -r -

--- a/suricatarunner-macOS
+++ b/suricatarunner-macOS
@@ -9,4 +9,4 @@ rule-files:
   - $dir/var/lib/suricata/rules/suricata.rules
 " >> $dir/brim-conf-run.yaml
 
-exec "$dir/bin/suricata" -c "$dir/brim-conf-run.yaml" --set classification-file="$dir/etc/suricata/classification.config" --set reference-config-file="$dir/etc/suricata/reference.config" --set threshold-file="$dir/etc/suricata/threshold.config" --set magic-file="$dir/share/file/magic.mgc" -r /dev/stdin
+exec "$dir/bin/suricata" -c "$dir/brim-conf-run.yaml" --set classification-file="$dir/etc/suricata/classification.config" --set reference-config-file="$dir/etc/suricata/reference.config" --set threshold-file="$dir/etc/suricata/threshold.config" --set magic-file="$dir/share/file/magic.mgc" -r -


### PR DESCRIPTION
Point to Brim's Suricata fork which has support for "-r -", and use
that rather than "-r /dev/stdin" in the macOS and linux runners.

This change is groundwork for Windows support where "-r /dev/stdin"
does not work.