### PR TITLE
Static linux build

### DIFF
--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -57,8 +57,8 @@ jobs:
         mkdir -p $HOME/suricata/share/file
         cp /usr/local/Cellar/libmagic/$version/share/misc/magic.mgc $HOME/suricata/share/file
     - name: create zip
-      run: cd $HOME && zip -r suricata-v5.0.3-brim8.$(go env GOOS)-$(go env GOARCH).zip suricata
+      run: cd $HOME && zip -r suricata-v5.0.3-brim9.$(go env GOOS)-$(go env GOARCH).zip suricata
     - if: github.ref == 'refs/heads/master'
       name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil cp $HOME/suricata-v5.0.3-brim8.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/
+        gsutil cp $HOME/suricata-v5.0.3-brim9.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/

--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -23,7 +23,7 @@ jobs:
         sudo apt-get -y install libpcre3 libpcre3-dev build-essential autoconf \
         automake libtool libpcap-dev libnet1-dev libyaml-0-2 libyaml-dev zlib1g zlib1g-dev \
         libcap-ng-dev libcap-ng0 make libmagic-dev libjansson-dev libjansson4 pkg-config libnss3-dev \
-        libnspr4-dev liblz4-dev zip
+        libnspr4-dev liblz4-dev zip rustc cargo
     - name: clone Suricata and autogen
       run: |
         git clone --depth 1 --branch brim-suricata-5.0.3 https://github.com/brimsec/suricata.git
@@ -38,7 +38,16 @@ jobs:
       working-directory: suricata/suricata-update
     - name: configure and build
       # --disable-gccmatch-native is to avoid "illegal instruction" crashes when running on a different x86_64 CPU.
-      run: cd suricata && ./configure --disable-gccmarch-native --enable-static=yes --enable-shared=no --prefix=$HOME/suricata && make -j2 && make install-full
+      run: cd suricata && ./configure --disable-gccmarch-native --enable-static=yes --enable-shared=no --prefix=$HOME/suricata && make -j2
+    - name: build static binary
+      run: |
+        cp Makefile-linux.brim suricata/src/Makefile.brim
+        cd suricata/src
+        # remove the dynamically-linked suricata and re-link statically using our Makefile
+        rm suricata
+        make -f Makefile.brim suricata
+        cd ..
+        make install-full
     - name: add brim files
       run: |
         cp brim-conf.yaml $HOME/suricata
@@ -48,4 +57,4 @@ jobs:
     - if: github.ref == 'refs/heads/master'
       name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil cp $HOME/suricata-v5.0.3-brim8.linux-amd64.zip gs://brimsec/suricata/
+        gsutil cp $HOME/suricata-v5.0.3-brim8.linux-amd64.zip gs://brimsec/suricata/PR-tmp-suricata-v5.0.3-brim8-static.linux-amd64.zip

--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -53,8 +53,8 @@ jobs:
         cp brim-conf.yaml $HOME/suricata
         cp suricatarunner-linux $HOME/suricata/suricatarunner
     - name: create zip
-      run: cd $HOME && zip -r suricata-v5.0.3-brim8.$(go env GOOS)-$(go env GOARCH).zip suricata
+      run: cd $HOME && zip -r suricata-v5.0.3-brim9.$(go env GOOS)-$(go env GOARCH).zip suricata
     - if: github.ref == 'refs/heads/master'
       name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil cp $HOME/suricata-v5.0.3-brim8.linux-amd64.zip gs://brimsec/suricata/PR-tmp-suricata-v5.0.3-brim8-static.linux-amd64.zip
+        gsutil cp $HOME/suricata-v5.0.3-brim9.linux-amd64.zip gs://brimsec/suricata/

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -96,9 +96,9 @@ jobs:
         cp suricatarunner.exe /home/runneradmin/suricata/suricatarunner.exe
     - name: create zip
       run: |
-        cd /home/runneradmin && zip -r suricata-v5.0.3-brim8.$(go env GOOS)-$(go env GOARCH).zip suricata
+        cd /home/runneradmin && zip -r suricata-v5.0.3-brim9.$(go env GOOS)-$(go env GOARCH).zip suricata
     - if: github.ref == 'refs/heads/master'
       name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil cp /home/runneradmin/suricata-v5.0.3-brim8.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/
+        gsutil cp /home/runneradmin/suricata-v5.0.3-brim9.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/
 

--- a/Makefile-linux.brim
+++ b/Makefile-linux.brim
@@ -1,0 +1,12 @@
+include Makefile
+
+LIBS := $(filter-out -lmagic -lrt -ldl -lcap-ng -lnet -lz -llz4 -lpcap -ljansson -lpcre -lyaml,$(LIBS))
+
+suricata_LDADD := $(filter-out -lrt,$(suricata_LDADD))
+
+static_libs = /usr/lib/x86_64-linux-gnu/libcap-ng.a /usr/lib/x86_64-linux-gnu/libjansson.a /usr/lib/x86_64-linux-gnu/libmagic.a /usr/lib/x86_64-linux-gnu/libnet.a /usr/lib/x86_64-linux-gnu/libpcap.a /usr/lib/x86_64-linux-gnu/libpcre.a  /usr/lib/x86_64-linux-gnu/librt.a /usr/lib/x86_64-linux-gnu/libyaml.a /usr/lib/x86_64-linux-gnu/libz.a /usr/lib/x86_64-linux-gnu/liblz4.a
+
+suricata$(EXEEXT): $(suricata_OBJECTS) $(suricata_DEPENDENCIES) $(EXTRA_suricata_DEPENDENCIES)
+	@rm -f suricata$(EXEEXT)
+	$(AM_V_CCLD)$(suricata_LINK) $(suricata_OBJECTS) $(suricata_LDADD) $(static_libs) $(LIBS)
+


### PR DESCRIPTION
This PR removes most dynamic dependencies from the suricata linux binary. 

The resulting deps are mostly standard system deps (and that our zeek executable has too)  such as libc, libdl, libpthread, ...

I was unable to link statically with nss and nspr (see #24). We can't expect these to be present on every linux system (they are on a standard ubuntu 18.04), so we'll have to add them as deps to the .deb/.rpm packages when building those in the brim repo. 


```
henridf@henridf-ubuntu-1804:~/suricata/src$ lddtree suricata
suricata => ./suricata (interpreter => /lib64/ld-linux-x86-64.so.2)
    libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1
    libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2
    libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6
    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0
    libnss3.so => /usr/lib/x86_64-linux-gnu/libnss3.so
        libnssutil3.so => /usr/lib/x86_64-linux-gnu/libnssutil3.so
        libplc4.so => /usr/lib/x86_64-linux-gnu/libplc4.so
        libplds4.so => /usr/lib/x86_64-linux-gnu/libplds4.so
    libnspr4.so => /usr/lib/x86_64-linux-gnu/libnspr4.so
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1
    libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1
    libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6
    ld-linux-x86-64.so.2 => /lib64/ld-linux-x86-64.so.2
```





