### PR TITLE
Use libpcap 1.9.1 on Ubuntu

### DIFF
--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -21,9 +21,12 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install libpcre3 libpcre3-dev build-essential autoconf \
-        automake libtool libpcap-dev libnet1-dev libyaml-0-2 libyaml-dev zlib1g zlib1g-dev \
-        libcap-ng-dev libcap-ng0 make libmagic-dev libjansson-dev libjansson4 pkg-config libnss3-dev \
+        automake libtool ninja-build libnet1-dev libyaml-0-2 libyaml-dev zlib1g zlib1g-dev \
+         libcap-ng-dev libcap-ng0 make libmagic-dev libjansson-dev libjansson4 pkg-config libnss3-dev \
         libnspr4-dev liblz4-dev zip rustc cargo
+    - name: build libpcap
+      run: |
+        ./build-libpcap
     - name: clone Suricata and autogen
       run: |
         git clone --depth 1 --branch brim-suricata-5.0.3 https://github.com/brimsec/suricata.git

--- a/build-libpcap
+++ b/build-libpcap
@@ -12,5 +12,20 @@ install_libpcap() {
     rm -r libpcap
 }
 
-install_libpcap /mingw64
+# Compile a recent libpcap since the ones we get in Ubuntu 18.04 and in mingw are
+# old and hits https://github.com/brimsec/zeek/issues/17.
+case $(uname) in
+    Linux)
+        sudo=sudo
+        install_libpcap /usr
+        ;;
+    *_NT-*)
+        install_libpcap /mingw64
+        ;;
+    *)
+        echo "unknown OS: $(uname)" >&2
+        exit 1
+        ;;
+esac
+
 


### PR DESCRIPTION
@philrz I verified that the existing suricata failed on the pcap from https://github.com/brimsec/zeek/issues/17, and the new version built here doesn't.