### PR TITLE
Add suricata-update to build

### DIFF
--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -48,9 +48,9 @@ jobs:
         make install-full
     - name: freeze suricata-update
       run: |
-        cd $HOME/suricata
-        PYTHONPATH=$(pwd)/lib/python3.8/site-packages pyinstaller --onefile bin/suricata-update
+        pyinstaller --onefile bin/suricata-update
         cp dist/suricata-update $HOME/suricata/bin
+      working-directory: suricata/suricata-update
     - name: add brim files
       run: |
         cp brim-conf.yaml $HOME/suricata

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -22,7 +22,7 @@ jobs:
         brew install rust pkg-config
         brew install jansson libmagic libnet libyaml lz4 nspr nss pcre bzip2
         brew install autoconf automake libtool
-        pip3 install pyyaml
+        pip3 install pyyaml pyinstaller
     - name: clone Suricata and autogen
       run: |
         git clone --depth 1 --branch brim-suricata-5.0.3 https://github.com/brimsec/suricata.git
@@ -32,7 +32,7 @@ jobs:
     - name: get suricata-update
       run: |
         curl -L \
-              https://github.com/OISF/suricata-update/archive/master.tar.gz | \
+              https://github.com/brimsec/suricata-update/archive/master.tar.gz | \
               tar zxvf - --strip-components=1
       working-directory: suricata/suricata-update
     - name: configure and build
@@ -46,9 +46,15 @@ jobs:
         make -f Makefile.brim
         cd ..
         make install-full
+    - name: freeze suricata-update
+      run: |
+        cd $HOME/suricata
+        PYTHONPATH=$(pwd)/lib/python3.8/site-packages pyinstaller --onefile bin/suricata-update
+        cp dist/suricata-update $HOME/suricata/bin
     - name: add brim files
       run: |
         cp brim-conf.yaml $HOME/suricata
+        cp suricataupdater $HOME/suricata
         cp suricatarunner-macOS $HOME/suricata/suricatarunner
     - name: add magic file
       run: |
@@ -57,8 +63,8 @@ jobs:
         mkdir -p $HOME/suricata/share/file
         cp /usr/local/Cellar/libmagic/$version/share/misc/magic.mgc $HOME/suricata/share/file
     - name: create zip
-      run: cd $HOME && zip -r suricata-v5.0.3-brim10.$(go env GOOS)-$(go env GOARCH).zip suricata
+      run: cd $HOME && zip -r suricata-v5.0.3-brim11.$(go env GOOS)-$(go env GOARCH).zip suricata
     - if: github.ref == 'refs/heads/master'
       name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil cp $HOME/suricata-v5.0.3-brim10.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/
+        gsutil cp $HOME/suricata-v5.0.3-brim11.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/

--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -23,7 +23,9 @@ jobs:
         sudo apt-get -y install libpcre3 libpcre3-dev build-essential autoconf \
         automake libtool ninja-build libnet1-dev libyaml-0-2 libyaml-dev zlib1g zlib1g-dev \
          libcap-ng-dev libcap-ng0 make libmagic-dev libjansson-dev libjansson4 pkg-config libnss3-dev \
-        libnspr4-dev liblz4-dev zip rustc cargo
+        libnspr4-dev liblz4-dev zip rustc cargo python3-setuptools
+        pip3 install wheel
+        pip3 install pyinstaller
     - name: build libpcap
       run: |
         ./build-libpcap
@@ -36,7 +38,7 @@ jobs:
     - name: get suricata-update
       run: |
         curl -L \
-              https://github.com/OISF/suricata-update/archive/master.tar.gz | \
+              https://github.com/brimsec/suricata-update/archive/master.tar.gz | \
               tar zxvf - --strip-components=1
       working-directory: suricata/suricata-update
     - name: configure and build
@@ -51,13 +53,19 @@ jobs:
         make -f Makefile.brim suricata
         cd ..
         make install-full
+    - name: freeze suricata-update
+      run: |
+        cd suricata/suricata-update
+        ~/.local/bin/pyinstaller --onefile bin/suricata-update
+        cp dist/suricata-update $HOME/suricata/bin
     - name: add brim files
       run: |
         cp brim-conf.yaml $HOME/suricata
+        cp suricataupdater $HOME/suricata
         cp suricatarunner-linux $HOME/suricata/suricatarunner
     - name: create zip
-      run: cd $HOME && zip -r suricata-v5.0.3-brim10.$(go env GOOS)-$(go env GOARCH).zip suricata
+      run: cd $HOME && zip -r suricata-v5.0.3-brim11.$(go env GOOS)-$(go env GOARCH).zip suricata
     - if: github.ref == 'refs/heads/master'
       name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil cp $HOME/suricata-v5.0.3-brim10.linux-amd64.zip gs://brimsec/suricata/
+        gsutil cp $HOME/suricata-v5.0.3-brim11.linux-amd64.zip gs://brimsec/suricata/

--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -55,9 +55,9 @@ jobs:
         make install-full
     - name: freeze suricata-update
       run: |
-        cd suricata/suricata-update
         ~/.local/bin/pyinstaller --onefile bin/suricata-update
         cp dist/suricata-update $HOME/suricata/bin
+      working-directory: suricata/suricata-update
     - name: add brim files
       run: |
         cp brim-conf.yaml $HOME/suricata

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -46,12 +46,6 @@ jobs:
         dos2unix.exe libhtp/htp.pc.in
         dos2unix.exe libhtp/Makefile.am
         ./autogen.sh
-    - name: get suricata-update
-      run: |
-        curl -L \
-              https://github.com/OISF/suricata-update/archive/master.tar.gz | \
-              tar zxvf - --strip-components=1
-      working-directory: suricata/suricata-update
     - name: configure and build
       run: |
         CFLAGS=-DPCRE_STATIC= ./configure --disable-shared --enable-static --enable-gccprotect --prefix /home/runneradmin/suricata
@@ -89,16 +83,24 @@ jobs:
       with:
         go-version: 1.14
     - name: build runner
-      run: go build -o suricatarunner.exe suricatarunner-windows.go
+      run: |
+        go build -o suricatarunner.exe go/runner/main.go
+        go build -o suricataupdater.exe go/updater/main.go
     - name: add brim files
       run: |
         cp brim-conf.yaml /home/runneradmin/suricata
-        cp suricatarunner.exe /home/runneradmin/suricata/suricatarunner.exe
+        cp suricatarunner.exe suricataupdater.exe /home/runneradmin/suricata/
+    - name: freeze suricata-update
+      run: |
+        curl -L https://github.com/brimsec/suricata-update/archive/fix-windows.tar.gz | tar zxvf - --strip-components=1
+        pip3 install pyinstaller
+        pyinstaller --onefile bin\suricata-update
+        cp dist\suricata-update.exe C:\msys64\home\runneradmin\suricata\bin
+      shell: cmd
     - name: create zip
       run: |
-        cd /home/runneradmin && zip -r suricata-v5.0.3-brim10.$(go env GOOS)-$(go env GOARCH).zip suricata
-    - if: github.ref == 'refs/heads/master'
+        cd /home/runneradmin && zip -r suricata-v5.0.3-brim11.$(go env GOOS)-$(go env GOARCH).zip suricata
+    - if:
       name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil cp /home/runneradmin/suricata-v5.0.3-brim10.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/suricata-v5.0.3-brim10.$(go env GOOS)-$(go env GOARCH).zip
-
+        gsutil cp /home/runneradmin/suricata-v5.0.3-brim11.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/suricata-v5.0.3-brim11.$(go env GOOS)-$(go env GOARCH).zip

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -100,7 +100,7 @@ jobs:
     - name: create zip
       run: |
         cd /home/runneradmin && zip -r suricata-v5.0.3-brim11.$(go env GOOS)-$(go env GOARCH).zip suricata
-    - if:
+    - if: github.ref == 'refs/heads/master'
       name: Upload release artifacts to Google Cloud Storage bucket
       run: |
         gsutil cp /home/runneradmin/suricata-v5.0.3-brim11.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/suricata-v5.0.3-brim11.$(go env GOOS)-$(go env GOARCH).zip

--- a/go/runner/main.go
+++ b/go/runner/main.go
@@ -1,9 +1,6 @@
-// +build windows
-
-// This tool executes suricata on windows, constructing the required SURICATA*
-// environment variables.  It embeds knowledge of the locations of the suricata
-// executable and suricata script locations in the expanded 'zdeps/suricata' directory
-// inside a Brim installation.
+// This tool executes suricata on windows.  It embeds knowledge of the locations of the suricata
+// executable and suricata paths in the expanded 'zdeps/suricata'
+// directory inside a Brim installation.
 package main
 
 import (

--- a/go/updater/main.go
+++ b/go/updater/main.go
@@ -1,0 +1,76 @@
+// This tool executes suricata-update on windows.  It embeds knowledge of the locations of the suricata
+// executable and suricata paths path in the expanded 'zdeps/suricata'
+// directory inside a Brim installation.
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// These paths are relative to the zdeps/suricata directory.
+var (
+	execRelPath = "bin/suricata-update.exe"
+)
+
+// zdepsSuricataDirectory returns the absolute path of the zdeps/suricata directory,
+// based on the assumption that this executable is located directly in it.
+func zdepsSuricataDirectory() (string, error) {
+	execFile, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Dir(execFile), nil
+}
+
+func makeConfig(baseDir, dest string) error {
+	ruleConfig := fmt.Sprintf(`
+data-directory: %s\var\lib\suricata
+dist-rule-directory: %s\share\suricata\rules
+`, baseDir, baseDir)
+
+	return ioutil.WriteFile(filepath.Join(baseDir, dest), []byte(ruleConfig), 0644)
+}
+
+func runSuricataUpdate(baseDir, execPath string) error {
+	cmd := exec.Command(execPath,
+		"--suricata", filepath.Join(baseDir, "bin/suricata.exe"),
+		"--config", filepath.Join(baseDir, "update.yaml"),
+		"--suricata-conf", filepath.Join(baseDir, "brim-conf.yaml"),
+		"--no-test",
+		"--no-reload")
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	path := fmt.Sprintf("PATH=%s;%s", filepath.Join(baseDir, "dlls"), os.Getenv("PATH"))
+	cmd.Env = append(os.Environ(), path)
+
+	return cmd.Run()
+}
+
+func main() {
+	baseDir, err := zdepsSuricataDirectory()
+	if err != nil {
+		log.Fatalln("zdepsSuricataDirectory failed:", err)
+	}
+
+	if err := makeConfig(baseDir, "update.yaml"); err != nil {
+		log.Fatalln("makeConfig failed:", err)
+	}
+
+	execPath := filepath.Join(baseDir, filepath.FromSlash(execRelPath))
+	if _, err := os.Stat(execPath); err != nil {
+		log.Fatalln("suricata-update executable not found at", execPath)
+	}
+
+	err = runSuricataUpdate(baseDir, execPath)
+	if err != nil {
+		log.Fatalln("launchSuricata failed", err)
+	}
+}

--- a/suricataupdater
+++ b/suricataupdater
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+echo "
+data-directory: $dir/var/lib/suricata
+dist-rule-directory: $dir/share/suricata/rules
+" >> $dir/update.yaml
+
+exec "$dir/bin/suricata-update" --suricata "$dir/bin/suricata" --suricata-conf "$dir/brim-conf.yaml" --conf $dir/update.yaml --no-test --no-reload

--- a/suricataupdater
+++ b/suricataupdater
@@ -5,6 +5,6 @@ dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 echo "
 data-directory: $dir/var/lib/suricata
 dist-rule-directory: $dir/share/suricata/rules
-" >> $dir/update.yaml
+" > $dir/update.yaml
 
 exec "$dir/bin/suricata-update" --suricata "$dir/bin/suricata" --suricata-conf "$dir/brim-conf.yaml" --conf $dir/update.yaml --no-test --no-reload


### PR DESCRIPTION
This change adds a pyinstaller-frozen suricata-update to our suricata
build on all three platforms.

It also adds a "suricataupdater" executable (shell script on unix-y
platforms, go binary on Windows) following the same strategy that we
took for the suricatarunner and zeekrunner.

As part of this work I had to fork suricata-update to fix some Windows
issues. This fork is used here pending the fixes being upstreamed.