### PR TITLE
Make suricata helpers userdir-aware

### DIFF
--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -63,8 +63,8 @@ jobs:
         mkdir -p $HOME/suricata/share/file
         cp /usr/local/Cellar/libmagic/$version/share/misc/magic.mgc $HOME/suricata/share/file
     - name: create zip
-      run: cd $HOME && zip -r suricata-v5.0.3-brim11.$(go env GOOS)-$(go env GOARCH).zip suricata
+      run: cd $HOME && zip -r suricata-v5.0.3-brim12.$(go env GOOS)-$(go env GOARCH).zip suricata
     - if: github.ref == 'refs/heads/master'
       name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil cp $HOME/suricata-v5.0.3-brim11.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/
+        gsutil cp $HOME/suricata-v5.0.3-brim12.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/

--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -64,8 +64,8 @@ jobs:
         cp suricataupdater $HOME/suricata
         cp suricatarunner-linux $HOME/suricata/suricatarunner
     - name: create zip
-      run: cd $HOME && zip -r suricata-v5.0.3-brim11.$(go env GOOS)-$(go env GOARCH).zip suricata
+      run: cd $HOME && zip -r suricata-v5.0.3-brim12.$(go env GOOS)-$(go env GOARCH).zip suricata
     - if: github.ref == 'refs/heads/master'
       name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil cp $HOME/suricata-v5.0.3-brim11.linux-amd64.zip gs://brimsec/suricata/
+        gsutil cp $HOME/suricata-v5.0.3-brim12.linux-amd64.zip gs://brimsec/suricata/

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -99,8 +99,8 @@ jobs:
       shell: cmd
     - name: create zip
       run: |
-        cd /home/runneradmin && zip -r suricata-v5.0.3-brim11.$(go env GOOS)-$(go env GOARCH).zip suricata
+        cd /home/runneradmin && zip -r suricata-v5.0.3-brim12.$(go env GOOS)-$(go env GOARCH).zip suricata
     - if: github.ref == 'refs/heads/master'
       name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil cp /home/runneradmin/suricata-v5.0.3-brim11.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/suricata-v5.0.3-brim11.$(go env GOOS)-$(go env GOARCH).zip
+        gsutil cp /home/runneradmin/suricata-v5.0.3-brim12.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/suricata-v5.0.3-brim12.$(go env GOOS)-$(go env GOARCH).zip

--- a/go/runner/main.go
+++ b/go/runner/main.go
@@ -31,7 +31,6 @@ func zdepsSuricataDirectory() (string, error) {
 
 func makeConfig(baseDir, source, dest string) error {
 	ruleConfig := fmt.Sprintf(`
-default-rule-path: %s\share\suricata\rules
 rule-files:
   - %s\var\lib\suricata\rules\suricata.rules
 `, baseDir, baseDir)

--- a/suricatarunner-linux
+++ b/suricatarunner-linux
@@ -2,10 +2,24 @@
 
 dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-cp $dir/brim-conf.yaml $dir/brim-conf-run.yaml
+if [ -z "$BRIM_SURICATA_USER_DIR" ]; then
+    userdir="$dir"
+    ruledir="$dir/var/lib/suricata/rules"
+else
+    userdir="$BRIM_SURICATA_USER_DIR"
+    ruledir="$userdir/rules"
+    if [ ! -d "$ruledir" ]; then
+        mkdir -p "$ruledir"
+    fi
+    if [ ! -f "$ruledir/suricata.rules" ]; then
+        cp "$dir/var/lib/suricata/rules/suricata.rules" "$ruledir"
+    fi
+fi
+
+cp $dir/brim-conf.yaml $userdir/brim-conf-run.yaml
 echo "
 rule-files:
-  - $dir/var/lib/suricata/rules/suricata.rules
-" >> $dir/brim-conf-run.yaml
+  - $ruledir/suricata.rules
+" >> $userdir/brim-conf-run.yaml
 
-exec "$dir/bin/suricata" -c "$dir/brim-conf-run.yaml" --set classification-file="$dir/etc/suricata/classification.config" --set reference-config-file="$dir/etc/suricata/reference.config" --set threshold-file="$dir/etc/suricata/threshold.config" -r -
+exec "$dir/bin/suricata" -c "$userdir/brim-conf-run.yaml" --set classification-file="$dir/etc/suricata/classification.config" --set reference-config-file="$dir/etc/suricata/reference.config" --set threshold-file="$dir/etc/suricata/threshold.config" -r -

--- a/suricatarunner-linux
+++ b/suricatarunner-linux
@@ -4,7 +4,6 @@ dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 cp $dir/brim-conf.yaml $dir/brim-conf-run.yaml
 echo "
-default-rule-path: $dir/share/suricata/rules
 rule-files:
   - $dir/var/lib/suricata/rules/suricata.rules
 " >> $dir/brim-conf-run.yaml

--- a/suricatarunner-macOS
+++ b/suricatarunner-macOS
@@ -4,7 +4,6 @@ dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 cp $dir/brim-conf.yaml $dir/brim-conf-run.yaml
 echo "
-default-rule-path: $dir/share/suricata/rules
 rule-files:
   - $dir/var/lib/suricata/rules/suricata.rules
 " >> $dir/brim-conf-run.yaml

--- a/suricatarunner-macOS
+++ b/suricatarunner-macOS
@@ -2,10 +2,24 @@
 
 dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-cp $dir/brim-conf.yaml $dir/brim-conf-run.yaml
+if [ -z "$BRIM_SURICATA_USER_DIR" ]; then
+    userdir="$dir"
+    ruledir="$dir/var/lib/suricata/rules"
+else
+    userdir="$BRIM_SURICATA_USER_DIR"
+    ruledir="$userdir/rules"
+    if [ ! -d "$ruledir" ]; then
+        mkdir -p "$ruledir"
+    fi
+    if [ ! -f "$ruledir/suricata.rules" ]; then
+        cp "$dir/var/lib/suricata/rules/suricata.rules" "$ruledir"
+    fi
+fi
+
+cp $dir/brim-conf.yaml $userdir/brim-conf-run.yaml
 echo "
 rule-files:
-  - $dir/var/lib/suricata/rules/suricata.rules
-" >> $dir/brim-conf-run.yaml
+  - $ruledir/suricata.rules
+" >> $userdir/brim-conf-run.yaml
 
-exec "$dir/bin/suricata" -c "$dir/brim-conf-run.yaml" --set classification-file="$dir/etc/suricata/classification.config" --set reference-config-file="$dir/etc/suricata/reference.config" --set threshold-file="$dir/etc/suricata/threshold.config" --set magic-file="$dir/share/file/magic.mgc" -r -
+exec "$dir/bin/suricata" -c "$userdir/brim-conf-run.yaml" --set classification-file="$dir/etc/suricata/classification.config" --set reference-config-file="$dir/etc/suricata/reference.config" --set threshold-file="$dir/etc/suricata/threshold.config" --set magic-file="$dir/share/file/magic.mgc" -r -

--- a/suricataupdater
+++ b/suricataupdater
@@ -2,9 +2,19 @@
 
 dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
+if [ -z "$BRIM_SURICATA_USER_DIR" ]; then
+    datadir="$dir/var/lib/suricata"
+else
+    datadir="$BRIM_SURICATA_USER_DIR"
+    if [ ! -d "$datadir" ]; then
+        mkdir -p "$datadir"
+    fi
+fi
+
+
 echo "
-data-directory: $dir/var/lib/suricata
+data-directory: $datadir
 dist-rule-directory: $dir/share/suricata/rules
-" > $dir/update.yaml
+" > $datadir/update.yaml
 
 exec "$dir/bin/suricata-update" --suricata "$dir/bin/suricata" --suricata-conf "$dir/brim-conf.yaml" --conf $dir/update.yaml --no-test --no-reload

--- a/suricataupdater
+++ b/suricataupdater
@@ -17,4 +17,4 @@ data-directory: $datadir
 dist-rule-directory: $dir/share/suricata/rules
 " > $datadir/update.yaml
 
-exec "$dir/bin/suricata-update" --suricata "$dir/bin/suricata" --suricata-conf "$dir/brim-conf.yaml" --conf $dir/update.yaml --no-test --no-reload
+exec "$dir/bin/suricata-update" --suricata "$dir/bin/suricata" --suricata-conf "$dir/brim-conf.yaml" --conf $datadir/update.yaml --no-test --no-reload "$@"


### PR DESCRIPTION
This PR changes the Suricata helpers to take into consideration a `BRIM_SURICATA_USER_DIR` environment variable. If present, the helpers   use that dir to write  suricata config and rules. Otherwise, the helpers continue to use the existing installation directory as previously.
    
This is motivated by Linux system wide installs where the install dir  is non-writable.

For consistency I'll do this for Windows, but likely in a follow-on PR.

The issue tracking this is https://github.com/brimsec/brim/1216