### PR TITLE
Use etc/ configuration files

### DIFF
--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -95,8 +95,8 @@ jobs:
         mkdir -p $HOME/suricata/share/file
         cp /usr/local/Cellar/libmagic/$version/share/misc/magic.mgc $HOME/suricata/share/file
     - name: create zip
-      run: cd $HOME && zip -r suricata-v5.0.3-brim21.$(go env GOOS)-$(go env GOARCH).zip suricata
+      run: cd $HOME && zip -r suricata-v5.0.3-brim22.$(go env GOOS)-$(go env GOARCH).zip suricata
     - if: github.ref == 'refs/heads/master'
       name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil cp $HOME/suricata-v5.0.3-brim21.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/
+        gsutil cp $HOME/suricata-v5.0.3-brim22.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/

--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -76,8 +76,8 @@ jobs:
         cp suricataupdater $HOME/suricata
         cp suricatarunner-linux $HOME/suricata/suricatarunner
     - name: create zip
-      run: cd $HOME && zip -r suricata-v5.0.3-brim21.$(go env GOOS)-$(go env GOARCH).zip suricata
+      run: cd $HOME && zip -r suricata-v5.0.3-brim22.$(go env GOOS)-$(go env GOARCH).zip suricata
     - if: github.ref == 'refs/heads/master'
       name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil cp $HOME/suricata-v5.0.3-brim21.linux-amd64.zip gs://brimsec/suricata/
+        gsutil cp $HOME/suricata-v5.0.3-brim22.linux-amd64.zip gs://brimsec/suricata/

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -113,8 +113,8 @@ jobs:
       shell: cmd
     - name: create zip
       run: |
-        cd /home/runneradmin && zip -r suricata-v5.0.3-brim21.$(go env GOOS)-$(go env GOARCH).zip suricata
+        cd /home/runneradmin && zip -r suricata-v5.0.3-brim22.$(go env GOOS)-$(go env GOARCH).zip suricata
     - if: github.ref == 'refs/heads/master'
       name: Upload release artifacts to Google Cloud Storage bucket
       run: |
-        gsutil cp /home/runneradmin/suricata-v5.0.3-brim21.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/suricata-v5.0.3-brim21.$(go env GOOS)-$(go env GOARCH).zip
+        gsutil cp /home/runneradmin/suricata-v5.0.3-brim22.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/suricata-v5.0.3-brim22.$(go env GOOS)-$(go env GOARCH).zip

--- a/go/runner/main.go
+++ b/go/runner/main.go
@@ -47,9 +47,9 @@ rule-files:
 func runSuricata(baseDir, execPath string) error {
 	cmd := exec.Command(execPath,
 		"-c", filepath.Join(baseDir, "brim-conf-run.yaml"),
-		"--set", fmt.Sprintf("classification-file=%s", filepath.FromSlash(filepath.Join(baseDir, "/share/suricata/classification.config"))),
-		"--set", fmt.Sprintf("reference-config-file=%s", filepath.FromSlash(filepath.Join(baseDir, "/share/suricata/reference.config"))),
-		"--set", fmt.Sprintf("threshold-file=%s", filepath.FromSlash(filepath.Join(baseDir, "/share/suricata/threshold.config"))),
+		"--set", fmt.Sprintf("classification-file=%s", filepath.FromSlash(filepath.Join(baseDir, "/etc/suricata/classification.config"))),
+		"--set", fmt.Sprintf("reference-config-file=%s", filepath.FromSlash(filepath.Join(baseDir, "/etc/suricata/reference.config"))),
+		"--set", fmt.Sprintf("threshold-file=%s", filepath.FromSlash(filepath.Join(baseDir, "/etc/suricata/threshold.config"))),
 		"-r", "-")
 
 	cmd.Stdin = os.Stdin

--- a/suricatarunner-linux
+++ b/suricatarunner-linux
@@ -23,4 +23,4 @@ rule-files:
   - $ruledir/suricata.rules
 " >> "$userdir/brim-conf-run.yaml"
 
-LD_LIBRARY_PATH="$dir/bin" exec "$dir/bin/suricata" -c "$userdir/brim-conf-run.yaml" --set classification-file="$dir/share/suricata/classification.config" --set reference-config-file="$dir/share/suricata/reference.config" --set threshold-file="$dir/share/suricata/threshold.config" -r -
+LD_LIBRARY_PATH="$dir/bin" exec "$dir/bin/suricata" -c "$userdir/brim-conf-run.yaml" --set classification-file="$dir/etc/suricata/classification.config" --set reference-config-file="$dir/etc/suricata/reference.config" --set threshold-file="$dir/etc/suricata/threshold.config" -r -

--- a/suricatarunner-macOS
+++ b/suricatarunner-macOS
@@ -23,4 +23,4 @@ rule-files:
   - $ruledir/suricata.rules
 " >> "$userdir/brim-conf-run.yaml"
 
-exec "$dir/bin/suricata" -c "$userdir/brim-conf-run.yaml" --set classification-file="$dir/share/suricata/classification.config" --set reference-config-file="$dir/share/suricata/reference.config" --set threshold-file="$dir/share/suricata/threshold.config" --set magic-file="$dir/share/file/magic.mgc" -r -
+exec "$dir/bin/suricata" -c "$userdir/brim-conf-run.yaml" --set classification-file="$dir/etc/suricata/classification.config" --set reference-config-file="$dir/etc/suricata/reference.config" --set threshold-file="$dir/etc/suricata/threshold.config" --set magic-file="$dir/share/file/magic.mgc" -r -


### PR DESCRIPTION
Undoes a change that mistakenly crept in with #45, and leads to an error message about threshold.config not being found.

Revert part of a previous commit which mistakenly switched the suricata runner to use the
share/ config files. (The fix was just to make the etc files readable,
and the share/ change was leftover that shouldn't have made it in).