### PR TITLE
Tagged releases

### DIFF
--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*brim*
 
 jobs:
   build:
@@ -100,9 +102,16 @@ jobs:
         rm -rf $HOME/suricata/lib
         rm -rf $HOME/suricata/include
     - name: create zip
-      run: cd $HOME && zip -r suricata-v5.0.3-brim25.$(go env GOOS)-$(go env GOARCH).zip suricata
-    - if: github.ref == 'refs/heads/master'
-      name: Upload release artifacts to Google Cloud Storage bucket
-      run: |
-        gsutil cp $HOME/suricata-v5.0.3-brim25.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/
-
+      run: zip -r suricata-$(git describe --always --tags).$(go env GOOS)-$(go env GOARCH).zip $HOME/suricata
+    - uses: actions/upload-artifact@v2
+      with:
+        name: macos
+        path: suricata-*.zip
+    - if: startsWith(github.event.ref, 'refs/tags/')
+      uses: svenstaro/upload-release-action@1.1.0
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: suricata-*.zip
+        file_glob: true
+        tag: ${{ github.ref }}
+        overwrite: true

--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*brim*
 
 jobs:
   build:
@@ -81,8 +83,16 @@ jobs:
         rm -rf $HOME/suricata/lib
         rm -rf $HOME/suricata/include
     - name: create zip
-      run: cd $HOME && zip -r suricata-v5.0.3-brim24.$(go env GOOS)-$(go env GOARCH).zip suricata
-    - if: github.ref == 'refs/heads/master'
-      name: Upload release artifacts to Google Cloud Storage bucket
-      run: |
-        gsutil cp $HOME/suricata-v5.0.3-brim24.linux-amd64.zip gs://brimsec/suricata/
+      run: zip -r suricata-$(git describe --always --tags).$(go env GOOS)-$(go env GOARCH).zip $HOME/suricata
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ubuntu
+        path: suricata-*.zip
+    - if: startsWith(github.event.ref, 'refs/tags/')
+      uses: svenstaro/upload-release-action@1.1.0
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: suricata-*.zip
+        file_glob: true
+        tag: ${{ github.ref }}
+        overwrite: true

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*brim*
 
 defaults:
  run:
@@ -117,9 +119,16 @@ jobs:
         rm -rf /home/runneradmin/suricata/lib
         rm -rf /home/runneradmin/suricata/include
     - name: create zip
-      run: |
-        cd /home/runneradmin && zip -r suricata-v5.0.3-brim25.$(go env GOOS)-$(go env GOARCH).zip suricata
-    - if: github.ref == 'refs/heads/master'
-      name: Upload release artifacts to Google Cloud Storage bucket
-      run: |
-        gsutil cp /home/runneradmin/suricata-v5.0.3-brim25.$(go env GOOS)-$(go env GOARCH).zip gs://brimsec/suricata/suricata-v5.0.3-brim25.$(go env GOOS)-$(go env GOARCH).zip
+      run: zip -r suricata-$(git describe --always --tags).$(go env GOOS)-$(go env GOARCH).zip $HOME/suricata
+    - uses: actions/upload-artifact@v2
+      with:
+        name: windows
+        path: suricata-*.zip
+    - if: startsWith(github.event.ref, 'refs/tags/')
+      uses: svenstaro/upload-release-action@1.1.0
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: suricata-*.zip
+        file_glob: true
+        tag: ${{ github.ref }}
+        overwrite: true


### PR DESCRIPTION
Move away from the per-PR version number scheme and towards a tag-based package creation approach. And store release artifacts as github releases rather than in the gcloud bucket. 

Closes #28 