### PR TITLE
Fix macOS build problem due to new LZ4 release

### DIFF
--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - fix-build-lz4
     tags:
       - v*brim*
 

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - fix-build-lz4
     tags:
       - v*brim*
 

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -13,12 +13,6 @@ jobs:
     runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
-    - name: Setup Google Cloud Platform
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-      with:
-        version: '290.0.1'
-        project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
-        service_account_key: ${{ secrets.GCLOUD_CREDENTIAL_BRIMSEC_BUCKET }}
     - name: install deps
       run: |
         brew install rust pkg-config

--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -13,12 +13,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - name: Setup Google Cloud Platform
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-      with:
-        version: '290.0.1'
-        project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
-        service_account_key: ${{ secrets.GCLOUD_CREDENTIAL_BRIMSEC_BUCKET }}
     - name: install deps
       run: |
         sudo apt-get update

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -22,12 +22,6 @@ jobs:
       run: echo 'C:\msys64\usr\bin' >> $GITHUB_PATH
     - name: Add mingw64 bin path
       run: echo "/mingw64/bin" >> $GITHUB_PATH
-    - name: Setup Google Cloud Platform
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-      with:
-        version: '290.0.1'
-        project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
-        service_account_key: ${{ secrets.GCLOUD_CREDENTIAL_BRIMSEC_BUCKET }}
     - name: install deps
       run: |
         pacman -Su --noconfirm libyaml-devel pcre-devel jansson-devel

--- a/Makefile-macOS.brim
+++ b/Makefile-macOS.brim
@@ -8,4 +8,4 @@ nspr_libs = /usr/local/opt/nspr/lib/libplc4.a /usr/local/opt/nspr/lib/libplds4.a
 
 suricata: $(suricata_OBJECTS) $(suricata_DEPENDENCIES) $(EXTRA_suricata_DEPENDENCIES)
 	@rm -f suricata$(EXEEXT)
-	$(AM_V_CCLD)$(suricata_LINK) $(suricata_OBJECTS) $(suricata_LDADD) /usr/local/Cellar/jansson/2.13.1/lib/libjansson.a /usr/local/Cellar/bzip2/1.0.8/lib/libbz2.a /usr/local/Cellar/libmagic/5.39/lib/libmagic.a /usr/local/Cellar/lz4/1.9.2/lib/liblz4.a /usr/local/Cellar/libnet/1.2/lib/libnet.a $(nss_libs) $(nspr_libs) /usr/local/Cellar/pcre/8.44/lib/libpcre.a /usr/local/Cellar/libyaml/0.2.5/lib/libyaml.a $(LIBS)
+	$(AM_V_CCLD)$(suricata_LINK) $(suricata_OBJECTS) $(suricata_LDADD) /usr/local/Cellar/jansson/2.13.1/lib/libjansson.a /usr/local/Cellar/bzip2/1.0.8/lib/libbz2.a /usr/local/Cellar/libmagic/5.39/lib/libmagic.a /usr/local/Cellar/lz4/1.9.3/lib/liblz4.a /usr/local/Cellar/libnet/1.2/lib/libnet.a $(nss_libs) $(nspr_libs) /usr/local/Cellar/pcre/8.44/lib/libpcre.a /usr/local/Cellar/libyaml/0.2.5/lib/libyaml.a $(LIBS)


### PR DESCRIPTION
The recently-observed build breakage on macOS was due to a new version of the LZ4 library. I suppose the fancier thing to do would be to try to lock in a specific LZ4 version or make the Makefile flexible to different release versions as they come out. But for now I'm just happy to force this to work again.

Not related, but some housecleaning I took care of at the same time: While I was in there, I noticed a warning because the Actions we'd used for Google Cloud are being deprecated. That's when I noticed that we're not even using Google Cloud in these workflows anymore, so for now I've just chosen to remove them.