### PR TITLE
Bundle a magic.mgc on Linux and point to it when running Suricata

### DIFF
--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - magic-fix-linux
     tags:
       - v*brim*
 

--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - magic-fix-linux
     tags:
       - v*brim*
 

--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -71,6 +71,10 @@ jobs:
         cp brim-conf.yaml $HOME/suricata
         cp suricataupdater $HOME/suricata
         cp suricatarunner-linux $HOME/suricata/suricatarunner
+    - name: add magic file
+      run: |
+        mkdir -p $HOME/suricata/share/file
+        cp /usr/lib/file/magic.mgc $HOME/suricata/share/file
     - name: prune unneeded installed files
       run: |
         rm -rf $HOME/suricata/share/doc

--- a/Makefile-macOS.brim
+++ b/Makefile-macOS.brim
@@ -1,6 +1,7 @@
 include Makefile
 
 LIBS = -lpcap -lpthread -lz
+libmagic_version = $(shell brew list --versions libmagic | cut -d ' ' -f 2)
 
 nss_libs = /usr/local/opt/nss/lib/libnss.a /usr/local/opt/nss/lib/libpkcs12.a /usr/local/opt/nss/lib/libpkixchecker.a /usr/local/opt/nss/lib/libcrmf.a /usr/local/opt/nss/lib/libnssutil.a /usr/local/opt/nss/lib/libpkixpki.a /usr/local/opt/nss/lib/libnssckfw.a /usr/local/opt/nss/lib/libsoftokn.a /usr/local/opt/nss/lib/libcpputil.a /usr/local/opt/nss/lib/libpkixsystem.a /usr/local/opt/nss/lib/libpkixmodule.a /usr/local/opt/nss/lib/libcerthi.a /usr/local/opt/nss/lib/libnssdbm.a /usr/local/opt/nss/lib/libpkixresults.a /usr/local/opt/nss/lib/libpkixstore.a /usr/local/opt/nss/lib/libfreebl.a /usr/local/opt/nss/lib/libpkixcrlsel.a /usr/local/opt/nss/lib/libpk11wrap.a /usr/local/opt/nss/lib/libsmime.a /usr/local/opt/nss/lib/libcertdb.a /usr/local/opt/nss/lib/libsectool.a /usr/local/opt/nss/lib/libgtest.a /usr/local/opt/nss/lib/libjar.a /usr/local/opt/nss/lib/libpkixparams.a /usr/local/opt/nss/lib/libdbm.a /usr/local/opt/nss/lib/libgtestutil.a /usr/local/opt/nss/lib/libpkixutil.a /usr/local/opt/nss/lib/libnssdev.a /usr/local/opt/nss/lib/libpkcs7.a /usr/local/opt/nss/lib/libnssb.a /usr/local/opt/nss/lib/libcryptohi.a /usr/local/opt/nss/lib/libpkixtop.a /usr/local/opt/nss/lib/libnsspki.a /usr/local/opt/nss/lib/libpkixcertsel.a
 nspr_libs = /usr/local/opt/nspr/lib/libplc4.a /usr/local/opt/nspr/lib/libplds4.a /usr/local/opt/nspr/lib/libnspr4.a
@@ -8,4 +9,4 @@ nspr_libs = /usr/local/opt/nspr/lib/libplc4.a /usr/local/opt/nspr/lib/libplds4.a
 
 suricata: $(suricata_OBJECTS) $(suricata_DEPENDENCIES) $(EXTRA_suricata_DEPENDENCIES)
 	@rm -f suricata$(EXEEXT)
-	$(AM_V_CCLD)$(suricata_LINK) $(suricata_OBJECTS) $(suricata_LDADD) /usr/local/Cellar/jansson/2.13.1/lib/libjansson.a /usr/local/Cellar/bzip2/1.0.8/lib/libbz2.a /usr/local/Cellar/libmagic/5.39/lib/libmagic.a /usr/local/Cellar/lz4/1.9.3/lib/liblz4.a /usr/local/Cellar/libnet/1.2/lib/libnet.a $(nss_libs) $(nspr_libs) /usr/local/Cellar/pcre/8.44/lib/libpcre.a /usr/local/Cellar/libyaml/0.2.5/lib/libyaml.a $(LIBS)
+	$(AM_V_CCLD)$(suricata_LINK) $(suricata_OBJECTS) $(suricata_LDADD) /usr/local/Cellar/jansson/2.13.1/lib/libjansson.a /usr/local/Cellar/bzip2/1.0.8/lib/libbz2.a /usr/local/Cellar/libmagic/$(libmagic_version)/lib/libmagic.a /usr/local/Cellar/lz4/1.9.3/lib/liblz4.a /usr/local/Cellar/libnet/1.2/lib/libnet.a $(nss_libs) $(nspr_libs) /usr/local/Cellar/pcre/8.44/lib/libpcre.a /usr/local/Cellar/libyaml/0.2.5/lib/libyaml.a $(LIBS)

--- a/suricatarunner-linux
+++ b/suricatarunner-linux
@@ -23,4 +23,4 @@ rule-files:
   - $ruledir/suricata.rules
 " >> "$userdir/brim-conf-run.yaml"
 
-LD_LIBRARY_PATH="$dir/bin" exec "$dir/bin/suricata" -c "$userdir/brim-conf-run.yaml" --set classification-file="$dir/etc/suricata/classification.config" --set reference-config-file="$dir/etc/suricata/reference.config" --set threshold-file="$dir/etc/suricata/threshold.config" -r -
+LD_LIBRARY_PATH="$dir/bin" exec "$dir/bin/suricata" -c "$userdir/brim-conf-run.yaml" --set classification-file="$dir/etc/suricata/classification.config" --set reference-config-file="$dir/etc/suricata/reference.config" --set threshold-file="$dir/etc/suricata/threshold.config" --set magic-file="$dir/share/file/magic.mgc" -r -


### PR DESCRIPTION
A community user recently reported the same symptoms as described in brimdata/brimcap#18. I don't know yet what specific Linux distribution they're running, but seeing the issue show up again motivated me to set up Arch Linux (against which brimdata/brimcap#18 was originally reported) and repro the problem on both the last GA Brim `v0.24.0` as well as the latest beta build https://storage.googleapis.com/brimsec-releases/brim/v0.25.0-prerelease-95581f92.0/linux/Brim-0.25.0-prerelease-95581f92.0.deb.

This is effectively the same fix we did for macOS in #7. My goal is to confirm that it makes the problem go away on Arch Linux without causing any trouble on the major distros like Ubuntu and RedHat where we've never had this problem.