### PR TITLE
Fix builds and advance Linux runner to ubuntu-20.04

### DIFF
--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - current-actions-runners
     tags:
       - v*brim*
 
@@ -18,17 +18,17 @@ jobs:
         brew install rust pkg-config
         brew install jansson libmagic libnet libyaml lz4 nspr nss pcre bzip2
         brew install autoconf automake libtool
-        pip3 install pyyaml pyinstaller
+        pip3 install pyyaml pyinstaller==4.5.1
     - name: clone Suricata and autogen
       run: |
-        git clone --depth 1 --branch brim-suricata-5.0.3 https://github.com/brimsec/suricata.git
+        git clone --depth 1 --branch brim-suricata-5.0.3 https://github.com/brimdata/suricata.git
         cd suricata
         git clone https://github.com/OISF/libhtp -b 0.5.x
         ./autogen.sh
     - name: get suricata-update
       run: |
         curl -L \
-              https://github.com/brimsec/suricata-update/archive/master.tar.gz | \
+              https://github.com/brimdata/suricata-update/archive/master.tar.gz | \
               tar zxvf - --strip-components=1
       working-directory: suricata/suricata-update
     - name: configure and build

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - current-actions-runners
+      - master
     tags:
       - v*brim*
 

--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - current-actions-runners
+      - master
     tags:
       - v*brim*
 

--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -4,13 +4,13 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - current-actions-runners
     tags:
       - v*brim*
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: install deps
@@ -21,20 +21,20 @@ jobs:
          libcap-ng-dev libcap-ng0 make libmagic-dev libjansson-dev libjansson4 pkg-config libnss3-dev \
         libnspr4-dev liblz4-dev zip rustc cargo python3-setuptools
         pip3 install wheel
-        pip3 install pyinstaller
+        pip3 install pyinstaller==4.5.1
     - name: build libpcap
       run: |
         ./build-libpcap
     - name: clone Suricata and autogen
       run: |
-        git clone --depth 1 --branch brim-suricata-5.0.3 https://github.com/brimsec/suricata.git
+        git clone --depth 1 --branch brim-suricata-5.0.3 https://github.com/brimdata/suricata.git
         cd suricata
         git clone https://github.com/OISF/libhtp -b 0.5.x
         ./autogen.sh
     - name: get suricata-update
       run: |
         curl -L \
-              https://github.com/brimsec/suricata-update/archive/master.tar.gz | \
+              https://github.com/brimdata/suricata-update/archive/master.tar.gz | \
               tar zxvf - --strip-components=1
       working-directory: suricata/suricata-update
     - name: configure and build

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - current-actions-runners
     tags:
       - v*brim*
 
@@ -35,7 +35,7 @@ jobs:
         ./build-libpcap
     - name: clone Suricata and autogen
       run: |
-        git clone --depth 1 --branch brim-suricata-5.0.3 https://github.com/brimsec/suricata.git
+        git clone --depth 1 --branch brim-suricata-5.0.3 https://github.com/brimdata/suricata.git
         cd suricata
         git clone https://github.com/OISF/libhtp -b 0.5.x
         dos2unix.exe libhtp/configure.ac
@@ -102,8 +102,8 @@ jobs:
         cp suricatarunner.exe suricataupdater.exe /home/runneradmin/suricata/
     - name: freeze suricata-update
       run: |
-        curl -L https://github.com/brimsec/suricata-update/archive/fix-windows.tar.gz | tar zxvf - --strip-components=1
-        pip3 install pyinstaller
+        curl -L https://github.com/brimdata/suricata-update/archive/fix-windows.tar.gz | tar zxvf - --strip-components=1
+        pip3 install pyinstaller==4.5.1
         pip3 install -r requirements.txt
         pip3 install pyyaml
         pyinstaller --onefile bin\suricata-update

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - current-actions-runners
+      - master
     tags:
       - v*brim*
 

--- a/Makefile-linux.brim
+++ b/Makefile-linux.brim
@@ -1,10 +1,10 @@
 include Makefile
 
-LIBS := $(filter-out -lmagic -lrt -ldl -lcap-ng -lnet -lz -llz4 -lpcap -ljansson -lpcre -lyaml,$(LIBS))
+LIBS := $(filter-out -lmagic -lrt -ldl -lcap-ng -lnet -lz -llz4 -lpcap -ljansson -lpcre -llzma -lbz2 -lyaml,$(LIBS))
 
 suricata_LDADD := $(filter-out -lrt,$(suricata_LDADD))
 
-static_libs = /usr/lib/x86_64-linux-gnu/libcap-ng.a /usr/lib/x86_64-linux-gnu/libjansson.a /usr/lib/x86_64-linux-gnu/libmagic.a /usr/lib/x86_64-linux-gnu/libnet.a /usr/lib/x86_64-linux-gnu/libpcap.a /usr/lib/x86_64-linux-gnu/libpcre.a  /usr/lib/x86_64-linux-gnu/librt.a /usr/lib/x86_64-linux-gnu/libyaml.a /usr/lib/x86_64-linux-gnu/libz.a /usr/lib/x86_64-linux-gnu/liblz4.a
+static_libs = /usr/lib/x86_64-linux-gnu/libcap-ng.a /usr/lib/x86_64-linux-gnu/libjansson.a /usr/lib/x86_64-linux-gnu/libmagic.a /usr/lib/x86_64-linux-gnu/libnet.a /usr/lib/x86_64-linux-gnu/libpcap.a /usr/lib/x86_64-linux-gnu/libpcre.a  /usr/lib/x86_64-linux-gnu/librt.a /usr/lib/x86_64-linux-gnu/libyaml.a /usr/lib/x86_64-linux-gnu/libz.a /usr/lib/x86_64-linux-gnu/liblz4.a /usr/lib/x86_64-linux-gnu/liblzma.a /usr/lib/x86_64-linux-gnu/libbz2.a
 
 suricata$(EXEEXT): $(suricata_OBJECTS) $(suricata_DEPENDENCIES) $(EXTRA_suricata_DEPENDENCIES)
 	@rm -f suricata$(EXEEXT)


### PR DESCRIPTION
As noted in https://github.com/brimdata/brimcap/issues/259#issuecomment-1183611066, while the changes in #64 allowed the build automation to run successfully and produce an artifact, the result actually ended up being broken. Specifically, the Suricata Update binary produced by `pyinstaller` complained of being unable to find a module.

```
$ ./suricataupdater 
Traceback (most recent call last):
  File "suricata-update", line 32, in <module>
ModuleNotFoundError: No module named 'suricata'
[2060] Failed to execute script 'suricata-update' due to unhandled exception!
```

I could repro this breakage even with the Ubuntu artifact, and I'd not touched that build automation at all in #64, so this indicated something else had changed on us in the time since we last built.

I hacked at this and found that I could make a working binary if I just rolled back to the version of `pyinstaller` as of when we last successfully built. Through further binary searching I found the first `pyinstaller` version that breaks is `4.6`, so here I've pinned to the version right before that. I don't see anything in their [4.6 changelog entry](https://pyinstaller.org/en/v5.3/CHANGES.html#id37) that sticks out as an explanation for the change, but I'm inclined to go with what works for now and look into making it work with current `pyinstaller` as need arises.

While I was under the hood, I remembered how GitHub is set to retire some of the older versions of the Actions Runners, so I took a shot at advancing those. For Linux, the move from `ubuntu-18.04` to `ubuntu-20.04` only needed a couple of library tweaks, so I've included that here. An attempt to make the macOS move from `macos-10.15` to `macos-11` was not so simple. In the interest of divide & conquer, rather than get into that here I'd like to merge this PR so I can get working artifacts that include the fix to https://github.com/brimdata/brimcap/issues/259 and then look into the Mac build stuff at a later date.

To test, I created a draft Suricata artifact https://github.com/brimdata/build-suricata/releases/tag/v5.0.3-brim3, then pointed at that from a test [Brimcap `suricata-v5.0.3-brim3` branch](https://github.com/brimdata/brimcap/tree/suricata-v5.0.3-brim3) that ran successfully through CI [here](https://github.com/brimdata/brimcap/actions/runs/2945359739) and  also a test [Brim suricata-v5.0.3-brim3 branch](https://github.com/brimdata/brim/tree/suricata-v5.0.3-brim3) that pointed at that Brimcap commit, and that ran successfully through CI [here](https://github.com/brimdata/brim/actions/runs/2949635573).