### PR TITLE
Build on macos-11 Actions runner

### DIFF
--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -41,12 +41,10 @@ jobs:
         rm suricata
         make -f Makefile.brim
         cd ..
-        mkdir -p /Users/runner/suricata/bin
-        ln -s /usr/local/bin/suricata-update /Users/runner/suricata/bin/suricata-update
         make install-full
         chmod og+r $HOME/suricata/etc/suricata/*
       env:
-        PYTHONPATH: /usr/local/lib/python3.10/site-packages/suricata_update-1.2.0-py3.10.egg
+        PYTHONPATH: /Users/runner/suricata/lib/python3.9/site-packages
     - name: add and fix dylibs
       run: |
         cd $HOME/suricata/bin

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -4,13 +4,13 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - macos-11-runner
     tags:
       - v*brim*
 
 jobs:
   build:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - name: install deps

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - macos-11-runner
+      - master
     tags:
       - v*brim*
 

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -41,10 +41,12 @@ jobs:
         rm suricata
         make -f Makefile.brim
         cd ..
+        mkdir -p /Users/runner/suricata/bin
+        ln -s /usr/local/bin/suricata-update /Users/runner/suricata/bin/suricata-update
         make install-full
         chmod og+r $HOME/suricata/etc/suricata/*
       env:
-        PYTHONPATH: /Users/runner/suricata/lib/python3.9/site-packages
+        PYTHONPATH: /usr/local/lib/python3.10/site-packages/suricata_update-1.2.0-py3.10.egg
     - name: add and fix dylibs
       run: |
         cd $HOME/suricata/bin

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -13,6 +13,9 @@ jobs:
     runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
     - name: install deps
       run: |
         brew install rust pkg-config

--- a/Makefile-macOS.brim
+++ b/Makefile-macOS.brim
@@ -2,6 +2,12 @@ include Makefile
 
 LIBS = -lpcap -lpthread -lz
 libmagic_version = $(shell brew list --versions libmagic | cut -d ' ' -f 2)
+libjansson_version = $(shell brew list --versions jansson | cut -d ' ' -f 2)
+libbzip2_version = $(shell brew list --versions bzip2 | cut -d ' ' -f 2)
+liblz4_version = $(shell brew list --versions lz4 | cut -d ' ' -f 2)
+libnet_version = $(shell brew list --versions libnet | cut -d ' ' -f 2)
+libpcre_version = $(shell brew list --versions pcre | cut -d ' ' -f 2)
+libyaml_version = $(shell brew list --versions libyaml | cut -d ' ' -f 2)
 
 nss_libs = /usr/local/opt/nss/lib/libnss.a /usr/local/opt/nss/lib/libpkcs12.a /usr/local/opt/nss/lib/libpkixchecker.a /usr/local/opt/nss/lib/libcrmf.a /usr/local/opt/nss/lib/libnssutil.a /usr/local/opt/nss/lib/libpkixpki.a /usr/local/opt/nss/lib/libnssckfw.a /usr/local/opt/nss/lib/libsoftokn.a /usr/local/opt/nss/lib/libpkixsystem.a /usr/local/opt/nss/lib/libpkixmodule.a /usr/local/opt/nss/lib/libcerthi.a /usr/local/opt/nss/lib/libnssdbm.a /usr/local/opt/nss/lib/libpkixresults.a /usr/local/opt/nss/lib/libpkixstore.a /usr/local/opt/nss/lib/libfreebl.a /usr/local/opt/nss/lib/libpkixcrlsel.a /usr/local/opt/nss/lib/libpk11wrap.a /usr/local/opt/nss/lib/libsmime.a /usr/local/opt/nss/lib/libcertdb.a /usr/local/opt/nss/lib/libsectool.a /usr/local/opt/nss/lib/libjar.a /usr/local/opt/nss/lib/libpkixparams.a /usr/local/opt/nss/lib/libdbm.a /usr/local/opt/nss/lib/libpkixutil.a /usr/local/opt/nss/lib/libnssdev.a /usr/local/opt/nss/lib/libpkcs7.a /usr/local/opt/nss/lib/libnssb.a /usr/local/opt/nss/lib/libcryptohi.a /usr/local/opt/nss/lib/libpkixtop.a /usr/local/opt/nss/lib/libnsspki.a /usr/local/opt/nss/lib/libpkixcertsel.a
 nspr_libs = /usr/local/opt/nspr/lib/libplc4.a /usr/local/opt/nspr/lib/libplds4.a /usr/local/opt/nspr/lib/libnspr4.a
@@ -9,4 +15,4 @@ nspr_libs = /usr/local/opt/nspr/lib/libplc4.a /usr/local/opt/nspr/lib/libplds4.a
 
 suricata: $(suricata_OBJECTS) $(suricata_DEPENDENCIES) $(EXTRA_suricata_DEPENDENCIES)
 	@rm -f suricata$(EXEEXT)
-	$(AM_V_CCLD)$(suricata_LINK) $(suricata_OBJECTS) $(suricata_LDADD) /usr/local/Cellar/jansson/2.14/lib/libjansson.a /usr/local/Cellar/bzip2/1.0.8/lib/libbz2.a /usr/local/Cellar/libmagic/$(libmagic_version)/lib/libmagic.a /usr/local/Cellar/lz4/1.9.3/lib/liblz4.a /usr/local/Cellar/libnet/1.2/lib/libnet.a $(nss_libs) $(nspr_libs) /usr/local/Cellar/pcre/8.45/lib/libpcre.a /usr/local/Cellar/libyaml/0.2.5/lib/libyaml.a $(LIBS)
+	$(AM_V_CCLD)$(suricata_LINK) $(suricata_OBJECTS) $(suricata_LDADD) /usr/local/Cellar/jansson/$(libjansson_version)/lib/libjansson.a /usr/local/Cellar/bzip2/$(libbzip2_version)/lib/libbz2.a /usr/local/Cellar/libmagic/$(libmagic_version)/lib/libmagic.a /usr/local/Cellar/lz4/$(liblz4_version)/lib/liblz4.a /usr/local/Cellar/libnet/$(libnet_version)/lib/libnet.a $(nss_libs) $(nspr_libs) /usr/local/Cellar/pcre/$(libpcre_version)/lib/libpcre.a /usr/local/Cellar/libyaml/$(libyaml_version)/lib/libyaml.a $(LIBS)


### PR DESCRIPTION
As noted in #65, when I was making the last round of fixes in the build system, I unsuccessfully tried to get things working on the `macos-11` Actions runner. This PR now covers that.

My failed attempts were all with the Python 3.10 which is the default on the `macos-11` runner. Seeing that the the `macos-10.15` runner has been using Python 3.9 and that's worked all this time, here I took a shot at forcing the use of Python 3.9 on the `macos-11` runner and sure enough that did the trick. The only other changes were just to some library versions referenced in `/usr/local/Cellar`, and to address those I re-used an existing pattern that fills in the versions dynamically, so that should cover us well for possible future builds.

Just to archive my hacking experience Python 3.10, I suspect that the problems are related to the [deprecation of Python distutils](https://peps.python.org/pep-0632/#:~:text=In%20Python%203.10%20and%203.11,platforms%20will%20not%20be%20added.). The problems I kept having were all during the use of the `setup.py` to install `suricata-update`. For instance, it got installed into the wrong directory despite the use of a `--prefix` parameter, which seemed to be now ignored whereas it was obeyed previously. As I tried to look at Python docs to further debug, the heading on every page effectively kept telling me "don't use this tooling anymore", hence my reason for taking the Python 3.9 shortcut. After the fact I also found https://redmine.openinfosecfoundation.org/issues/5313 and https://github.com/OISF/suricata-update/commit/4920cf317c75160a62b6ce667da8132bf2a3db76 that seem to indicate the Suricata people are starting to address things in this area, but it's surely not a good investment in our time to try to backport. I'd guess that if we one day want to improve our security dependencies we could invest in someone's time to re-port our Suricata _and_ Zeek to current releases and knock out this class of issues all at once.

In addition to my own successful smoke test, here's successful Actions CI runs for both Brimcap and Brim that use a draft Suricata artifact from this branch.
* https://github.com/brimdata/brimcap/actions/runs/2966327210
* https://github.com/brimdata/brim/actions/runs/2966395270