### PR TITLE
Upgrade to actions/checkout@v3 in CI

### DIFF
--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'

--- a/.github/workflows/ubuntu-build.yaml
+++ b/.github/workflows/ubuntu-build.yaml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: install deps
       run: |
         sudo apt-get update

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -17,7 +17,7 @@ jobs:
 
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use MSYS2's bash.exe in subsequent steps.
       run: echo 'C:\msys64\usr\bin' >> $GITHUB_PATH
     - name: Add mingw64 bin path


### PR DESCRIPTION
v2 is deprecated because it uses Node.js 12, which is no longer supported.

(inspired by https://github.com/brimdata/zed/pull/4185)